### PR TITLE
colors: chalk.gray -> primary

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports = function garnish(opt) {
     function write(data) {
         //print null/undefined/string/etc
         if (typeof data === 'string')
-            return chalk.gray(pad(data))
+            return pad(data)
 
         var level = data.level || 'info'
         if (!verbose && !succeed(loggerLevel, level))


### PR DESCRIPTION
`garnish` doesn't render nicely on dark backgrounds, this patch solves that. Thanks! ✨

<img width="578" alt="screen shot 2015-07-23 at 14 27 41" src="https://cloud.githubusercontent.com/assets/2467194/8843137/c91207ea-3147-11e5-97bf-1b6163196123.png">

## Changes
- __colors__: Drop `chalk.gray` in favor of the primary terminal color, removing issues with dark / bright screens