### PR TITLE
color: replace gray with default terminal color

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = function garnish (opt) {
     }
 
     if (data.message) {
-      line.push(chalk.gray(data.message))
+      line.push(data.message)
     } else if (data.url && data.elapsed && data.type) {
       line.push([url, chalk.magenta(type), chalk.green(data.elapsed)].join(' '))
     } else if (data.url && data.type) {


### PR DESCRIPTION
Noticed there was another instance of black on black. This should make it render nicely on all background colors. Thanks!

<img width="428" alt="screen shot 2015-08-08 at 15 57 01" src="https://cloud.githubusercontent.com/assets/2467194/9149386/bbe5b9ea-3dea-11e5-970e-9b15d304b299.png">
