### PR TITLE
write: change line log

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,20 @@ Returns a duplexer that parses input as ndjson, and writes a pretty-printed resu
 
 - `level` the minimum level to listen for, defaults to `"info"`
 
-
 ## format
+PRs and suggestions welcome for other tools (Webpack? Watchify? Beefy? etc).
+Currently handles [bole](https://github.com/rvagg/bole) logs with some added
+flair for the following:
+- __level__ _(required)_: the loglevel (e.g. `debug`, `info`, `error`)
+- __name__: an optional event name. It's recommended to always have a name.
+- __message__: an event message.
+- __url__: an url. Useful for router logging.
+- __statusCode__: an HTTP statusCode. Codes `>=400` are displayed in red.
+- __contentLength__: the response size.
+- __elapsed__: time elapsed since the previous related event.
+- __type__: the type of event logged.
 
-PRs and suggestions welcome for other tools (Webpack? Watchify? Beefy? etc). Currently handles [bole](https://github.com/rvagg/bole) logs with some added flair for the following:
-
+__example__
 ```js
 //simple event
 { type: 'generated', url: '/' }
@@ -61,10 +70,6 @@ PRs and suggestions welcome for other tools (Webpack? Watchify? Beefy? etc). Cur
 //timed event with type
 { type: 'foo', url: '/blah.js', elapsed: '325ms' }
 ```
-
-Messages with `url`, `type` and `elapsed` have a stronger emphasis, messages with just `url` and `type` will be dimmed. 
-
-Other messages are printed as usual, with the log name (if available) and level. 
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,16 @@ var padLen = Object.keys(colors).reduce(function (prev, a) {
 }, 0)
 
 var pool = [ 'magenta', 'cyan', 'blue', 'green', 'yellow' ]
-var keys = [ 'level', 'message', 'url', 'elapsed', 'type', 'name' ]
+var keys = [
+  'level',
+  'name',
+  'message',
+  'url',
+  'statusCode',
+  'contentLength',
+  'elapsed',
+  'type'
+]
 
 var levels = Object.keys(colors)
 
@@ -65,20 +74,17 @@ module.exports = function garnish (opt) {
     var levelColor = colors[level] || 'yellow'
     var type = ['(', data.type, ')'].join('')
     var url = chalk.bold(data.url || '')
+    var statusColor = data.statusCode >= 400 ? 'red' : 'green'
 
+    // create line output
     line.push(chalk[levelColor](pad(level, padLen)))
-
-    if (name) {
-      line.push(chalk[nameColor](name + ':'))
-    }
-
-    if (data.message) {
-      line.push(data.message)
-    } else if (data.url && data.elapsed && data.type) {
-      line.push([url, chalk.magenta(type), chalk.green(data.elapsed)].join(' '))
-    } else if (data.url && data.type) {
-      line.push([url, chalk.dim(type)].join(' '))
-    }
+    if (name) line.push(chalk[nameColor](name + ':'))
+    if (data.message) line.push(data.message)
+    if (data.url) line.push(url)
+    if (data.statusCode) line.push(chalk[statusColor](data.statusCode))
+    if (data.contentLength) line.push(chalk.dim(data.contentLength))
+    if (data.elapsed) line.push(chalk.green(data.elapsed))
+    if (data.type) line.push(chalk.dim(type))
 
     return line.join(' ')
   }

--- a/test/test.js
+++ b/test/test.js
@@ -32,7 +32,17 @@ test('should handle streams', function (t) {
   run({ url: '/home', type: 'static', name: 'app' }, 'info app: /home (static)')
 
   // // test url and type + elapsed
-  run({ url: '/home', type: 'static', elapsed: 'infinity', name: 'app' }, 'info app: /home (static) infinity')
+  run({ url: '/home', type: 'static', elapsed: 'infinity', name: 'app' }, 'info app: /home infinity (static)')
+
+  // test everything
+  run({
+    name: 'http',
+    url: '/home',
+    type: 'http',
+    statusCode: '200',
+    contentLength: '12b',
+    elapsed: '24ms'
+  }, 'info http: /home 200 12b 24ms (http)')
   t.end()
 
   function ignored (input, msg, opt) {


### PR DESCRIPTION
This patch allows `garnish` to act as a human-friendly server logger by including things like `statusCode` and `responseSize`. In addition options are more loosely coupled now (had trouble with this in the past) and fully documented. Thanks! :sparkles:

## changes
- only `name` is now required
- added `statusCode` & `contentLength`
- changed order of log in some cases
- changed color of log in some combinations
- documented options