### PR TITLE
refactor + color styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Currently garnish styles the following:
 - `contentLength` - the response size.
 - `elapsed` - time elapsed since the previous related event.
 - `type` - the type of event logged.
-- `color` - an optional color mapping for custom styles
+- `colors` - an optional color mapping for custom styles
 
 For example:
 
@@ -90,7 +90,7 @@ For example:
 { type: 'foo', url: '/blah.js', elapsed: '325ms', name: 'http' }
 ```
 
-You can use the `color` field to override any of the default colors with a new [ANSI style](https://github.com/chalk/ansi-styles). 
+You can use the `colors` field to override any of the default colors with a new [ANSI style](https://github.com/chalk/ansi-styles). 
 
 For example, the following will print `elapsed` in yellow if it passes our threshold:
 
@@ -104,7 +104,7 @@ function logTime (msg) {
     name: 'app',
     message: msg,
     elapsed: time + ' ms',
-    color: {
+    colors: {
       elapsed: time > 1000 ? 'yellow' : 'green'
     }
   })

--- a/README.md
+++ b/README.md
@@ -2,21 +2,21 @@
 
 [![stable](http://badges.github.io/stability-badges/dist/stable.svg)](http://github.com/badges/stability-badges)
 
-![img](http://i.imgur.com/8OP1YPB.png)
+![screen](http://i.imgur.com/a6lMvDY.png)
 
-Prettifies [ndjson](http://ndjson.org/) or [bole](https://github.com/rvagg/bole) logs from [budo](https://github.com/mattdesl/budo), [wzrd](https://github.com/maxogden/wzrd/), [wtch](https://github.com/mattdesl/wtch) and other tools. Similar to [bistre](https://github.com/hughsk/bistre).
+Prettifies [ndjson](http://ndjson.org/) or [bole](https://github.com/rvagg/bole) logs from [budo](https://github.com/mattdesl/budo), [wzrd](https://github.com/maxogden/wzrd/) and other tools. Similar to [bistre](https://github.com/hughsk/bistre).
 
 Install: 
 
 ```sh
-npm install wzrd garnish --save-dev
+npm install budo garnish --save-dev
 ```
 
 Then in npm scripts:
 
 ```json
   "scripts": {
-    "start": "wzrd index.js | garnish"
+    "start": "budo index.js | garnish"
   }
 ```
 
@@ -24,12 +24,12 @@ Then `npm start` on your project to see it in action.
 
 ## Usage
 
-[![NPM](https://nodei.co/npm/garnish.png)](https://www.npmjs.com/package/garnish)
+### CLI
 
-## CLI
+Pipe a ndjson emitter into `garnish` like so:
 
 ```sh
-wzrd index.js | garnish [opts]
+node app.js | garnish [opts]
 
 Options:
     
@@ -41,34 +41,75 @@ Where `level` can be `debug`, `info`, `warn`, `error`.
 
 If `--verbose` is specified, `--level` will be ignored.
 
-## API
+### API
 
-#### `garnish(opt)`
+#### `garnish([opt])`
 
 Returns a duplexer that parses input as ndjson, and writes a pretty-printed result. Options:
 
-- `level` the minimum level to listen for, defaults to `"info"`
+- `level` (String)
+  - the minimum log level to print (default `'info'`)
+  - the order is as follows: `debug`, `info`, `warn`, `error`
+- `verbose` (Boolean)
+  - if true, `opt.level` is ignored and all messages will be printed (default `false`)
+
 
 ## format
-PRs and suggestions welcome for other tools (Webpack? Watchify? Beefy? etc).
-Currently handles [bole](https://github.com/rvagg/bole) logs with some added
-flair for the following:
-- __level__: the loglevel e.g. `debug`, `info`, `error` (default `info`)
-- __name__: an optional event or application name. It's recommended to always have a name.
-- __message__: an event message.
-- __url__: a url (stripped to pathname), useful for router logging.
-- __statusCode__: an HTTP statusCode. Codes `>=400` are displayed in red.
-- __contentLength__: the response size.
-- __elapsed__: time elapsed since the previous related event.
-- __type__: the type of event logged.
 
-__example__
+Typically, you would use [bole](https://github.com/rvagg/bole) or [ndjson](https://www.npmjs.com/package/ndjson) to write the content to garnish. You can also write ndjson to `stdout` like so:
+
+```js
+console.log({
+  name: 'myApp',
+  level: 'warn',
+  message: 'not found',
+  statusCode: 404,
+  url: '/foo.txt'
+})
+```
+
+Currently garnish styles the following:
+
+- `level` - the log level e.g. `debug`, `info`, `warn`, `error` (default `info`)
+- `name` - an optional event or application name. It's recommended to always have a name.
+- `message` - an event message.
+- `url` - a url (stripped to pathname), useful for router logging.
+- `statusCode` - an HTTP statusCode. Codes `>=400` are displayed in red.
+- `contentLength` - the response size.
+- `elapsed` - time elapsed since the previous related event.
+- `type` - the type of event logged.
+- `color` - an optional color mapping for custom styles
+
+For example:
+
 ```js
 //simple event
 { type: 'generated', url: '/' }
 
-//timed event with type
-{ type: 'foo', url: '/blah.js', elapsed: '325ms' }
+//timed event with type and name
+{ type: 'foo', url: '/blah.js', elapsed: '325ms', name: 'http' }
+```
+
+You can use the `color` field to override any of the default colors with a new [ANSI style](https://github.com/chalk/ansi-styles). 
+
+For example, the following will print `elapsed` in yellow if it passes our threshold:
+
+```js
+function logTime (msg) {
+  var now = Date.now()
+  var time = now - lastTime
+  lastTime = now
+    
+  console.log({
+    name: 'app',
+    message: msg,
+    elapsed: time + ' ms',
+    color: {
+      elapsed: time > 1000 ? 'yellow' : 'green'
+    }
+  })
+}
+  
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = function garnish (opt) {
     if (!verbose && !levels.valid(loggerLevel, data.level)) {
       return null
     }
-    
+
     return render(data)
   }
 }

--- a/lib/levels.js
+++ b/lib/levels.js
@@ -1,0 +1,38 @@
+var colors = {
+  debug: 'cyan',
+  info: 'blue',
+  warn: 'yellow',
+  error: 'red'
+}
+
+var padLen = Object.keys(colors).reduce(function (prev, a) {
+  return Math.max(prev, a.length)
+}, 0)
+
+var levels = Object.keys(colors)
+
+// whether the message level is valid for the given logger
+module.exports.valid = function (logLevel, msgLevel) {
+  var levelIdx = levels.indexOf(logLevel)
+  var msgIdx = levels.indexOf(msgLevel)
+  if (msgIdx === -1 || levelIdx === -1) return true
+  return msgIdx >= levelIdx
+}
+
+// stringify with padding
+module.exports.stringify = function (level) {
+  return pad(level, padLen)
+}
+
+// get a level's default color
+module.exports.color = function (level) {
+  return colors[level]
+}
+
+function pad (str, len) {
+  str = String(str)
+  while (str.length < len) {
+    str = ' ' + str
+  }
+  return str
+}

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -33,7 +33,7 @@ module.exports.create = function () {
   return function render (data) {
     var level = data.level
     var name = data.name
-    
+
     if (name && !poolIndex[name]) {
       poolIndex[name] = pool[poolCount % pool.length]
       poolCount++

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,0 +1,92 @@
+var chalk = require('chalk')
+var stripUrl = require('./strip-url')
+var levels = require('./levels')
+
+var ansiStyles = Object.keys(chalk.styles)
+var pool = [ 'magenta', 'cyan', 'blue', 'green', 'yellow' ]
+var keys = [
+  'level',
+  'name',
+  'message',
+  'url',
+  'statusCode',
+  'contentLength',
+  'elapsed',
+  'type'
+]
+
+module.exports.isStyleObject = function (data) {
+  // skip false/undefined/etc
+  if (typeof data !== 'object' || !data) {
+    return false
+  }
+  // ensure we have something worth styling
+  return keys.some(function (key) {
+    return data.hasOwnProperty(key)
+  })
+}
+
+module.exports.create = function () {
+  var poolCount = 0
+  var poolIndex = {}
+
+  return function render (data) {
+    var level = data.level
+    var name = data.name
+    
+    if (name && !poolIndex[name]) {
+      poolIndex[name] = pool[poolCount % pool.length]
+      poolCount++
+    }
+
+    // some default colors
+    var defaultColors = {
+      level: levels.color(level) || 'yellow',
+      name: name ? poolIndex[name] : null,
+      url: 'bold',
+      statusCode: data.statusCode >= 400 ? 'red' : 'green',
+      contentLength: 'dim',
+      elapsed: 'green',
+      type: 'dim'
+    }
+
+    // possible user overrides
+    var colors = data.colors || {}
+
+    // clean up the messages a little
+    data.level = levels.stringify(level)
+    if (name) data.name = name + ':'
+    if (data.url) data.url = stripUrl(data.url)
+    if (data.type) data.type = '(' + data.type + ')'
+
+    var line = []
+    // render each of our valid keys
+    keys.forEach(function (key) {
+      var value = data[key]
+
+      // skip empty data
+      if (!value) return
+
+      // colorize chunk
+      var newColor = getColor(key, colors, defaultColors)
+
+      if (newColor) {
+        value = chalk[newColor](value)
+      }
+
+      line.push(value)
+    })
+    return line.join(' ')
+  }
+}
+
+function getColor (key, colors, defaultColors) {
+  // try to apply user style
+  var newColor = colors[key]
+
+  // use default if style is invalid
+  if (ansiStyles.indexOf(newColor) === -1) {
+    newColor = null
+  }
+  return newColor || defaultColors[key]
+}

--- a/lib/strip-url.js
+++ b/lib/strip-url.js
@@ -1,0 +1,12 @@
+var urlLib = require('url')
+
+module.exports = stripUrl
+function stripUrl (url) {
+  if (!url) return ''
+  var obj = urlLib.parse(url)
+  obj.pathname = (obj.pathname || '').replace(/\/$/, '')
+  obj.search = ''
+  obj.hash = ''
+  obj.query = ''
+  return urlLib.format(obj) || '/'
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garnish",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "prettifies ndjson from wzrd and similar tools",
   "main": "index.js",
   "license": "MIT",

--- a/test/app.js
+++ b/test/app.js
@@ -3,8 +3,23 @@
 //    npm run demo -- --verbose
 
 console.log('Start!')
-console.log(JSON.stringify({ name: 'app', url: 'foo/bar', elapsed: '32ms', type: 'bundle' }))
-console.log(JSON.stringify({ name: 'app', url: 'foo/bar', type: 'bundle' }))
+console.log(JSON.stringify({ name: 'app', url: '/foo/bar', elapsed: '32ms', type: 'bundle' }))
+console.log(JSON.stringify({ name: 'app', url: '/foo/bar', type: 'bundle' }))
+console.log(JSON.stringify({
+  name: 'app', url: '/foo/bar', type: 'static',
+  statusCode: 404, contentLength: 1220
+}))
+console.log(JSON.stringify({
+  name: 'app:12345678', url: '/foo/bar', type: 'bundle',
+  elapsed: '325ms', message: 'hello world',
+  colors: {
+    message: 'blue',
+    elapsed: 'yellow',
+    name: 'green',
+    level: 'gray',
+    type: 'blue'
+  }
+}))
 console.log({})
 var obj = new Buffer([])
 console.log(obj)


### PR DESCRIPTION
Changes:

- refactored source a bit, splitting things into different files
- updates to readme
- removed the regex replace [here](https://github.com/mattdesl/garnish/blob/3ba8f85171730b86da21799f14f37db8ba7b01b7/index.js#L66) since it isn't clear why it was needed (originally from @hughsk's bistre)
- added support for `colors` field

Currently I'm eyeballing it with `npm run demo` but it would be good to actually check the ANSI codes to make sure they line up.

/cc @yoshuawuyts 