### PR TITLE
index: refactor

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+var stdout = require('stdout-stream')
 var garnish = require('../')
 var argv = require('minimist')(process.argv.slice(2))
 
@@ -8,4 +9,4 @@ process.stdin.resume()
 process.stdin.setEncoding('utf8')
 process.stdin
   .pipe(garnish(argv))
-  .pipe(process.stdout)
+  .pipe(stdout)

--- a/index.js
+++ b/index.js
@@ -1,52 +1,34 @@
-var through2 = require('through2')
-var duplexer = require('duplexer')
 var split = require('split2')
-var levels = require('./lib/levels')
-var renderer = require('./lib/renderer')
+var eol = require('os').EOL
 
-module.exports = function garnish (opt) {
+var renderer = require('./lib/renderer')
+var levels = require('./lib/levels')
+
+module.exports = garnish
+
+function garnish (opt) {
   opt = opt || {}
+
   var loggerLevel = opt.level || 'info'
   var verbose = opt.verbose
   var render = renderer.create()
 
-  var out = through2()
-  var parse = split().on('data', onData)
-  var dup = duplexer(parse, out)
-  return dup
+  return split(parse)
 
-  function onData (data) {
-    // see if we should style it
-    var style = parseData(data)
-    if (style) {
-      data = write(style)
-      // if skipping certain log levels
-      if (!data) {
-        return
-      }
+  function parse (line) {
+    try {
+      var obj = JSON.parse(line)
+
+      // check if we need to style it
+      if (!renderer.isStyleObject(obj)) return line + eol
+      obj.level = obj.level || 'info'
+
+      // allow user to filter to a specific level
+      if (!verbose && !levels.valid(loggerLevel, obj.level)) return
+
+      return render(obj) + eol
+    } catch (e) {
+      return line + eol
     }
-
-    out.push(data + '\n')
-  }
-
-  function write (data) {
-    // level defaults to 'info'
-    data.level = data.level || 'info'
-
-    // allow user to filter to a specific level
-    if (!verbose && !levels.valid(loggerLevel, data.level)) {
-      return null
-    }
-
-    return render(data)
-  }
-}
-
-function parseData (data) {
-  try {
-    var json = JSON.parse(data)
-    return renderer.isStyleObject(json) ? json : null
-  } catch (e) {
-    return null
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   },
   "dependencies": {
     "chalk": "^0.5.1",
-    "duplexer": "^0.1.1",
     "minimist": "^1.1.0",
     "split2": "^0.2.1",
+    "stdout-stream": "^1.4.0",
     "through2": "^0.6.3",
     "url-trim": "^1.0.0"
   },


### PR DESCRIPTION
I was running into a bug with `bole` and had a bit of trouble debugging the `garnish` code; this should hopefully make it just a lil bit better (': Thanks!

## Changes
- turned multiple stream calls into a single stream (less code! :D )
- errors are now correctly propagated because it's a single stream
- piping to stdout is now non-blocking (thank you `stdout-stream`)
- newlines will now render correctly cross-platform (copied the `ndjson` approach)

__edit:__ also closes #3, `ndjson` has a slightly different purpose, the current implementation of `garnish` is close enough / should be faster than piping out from garnish