### PR TITLE
cli: accept bunyan style logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ node app.js | garnish [opts]
 Options:
 
     --level, -l    the minimum debug level, default 'debug'
+    --bunyan, -b   parse bunyan logs
 ```
 
 Where `level` can be `debug`, `info`, `warn`, `error`.

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -4,6 +4,7 @@ var garnish = require('../')
 var argv = require('minimist')(process.argv.slice(2))
 
 argv.level = argv.level || argv.l
+argv.bunyan = argv.bunyan || argv.b
 process.stdin.resume()
 process.stdin.setEncoding('utf8')
 process.stdin

--- a/index.js
+++ b/index.js
@@ -18,6 +18,8 @@ function garnish (opt) {
     try {
       var obj = JSON.parse(line)
 
+      if (opt.bunyan) toBunyan(obj)
+
       // check if we need to style it
       if (!renderer.isStyleObject(obj)) return line + eol
       obj.level = obj.level || 'info'
@@ -29,5 +31,21 @@ function garnish (opt) {
     } catch (e) {
       return line + eol
     }
+  }
+}
+
+// mutate a bole log to bunyan log
+// obj -> null
+function toBunyan (obj) {
+  if (obj.msg && !obj.message) {
+    obj.message = obj.msg
+    delete obj.msg
+  }
+
+  if (typeof obj.level === 'number') {
+    if (obj.level === 20) obj.level = 'debug'
+    if (obj.level === 30) obj.level = 'info'
+    if (obj.level === 40) obj.level = 'warn'
+    if (obj.level === 50) obj.level = 'error'
   }
 }


### PR DESCRIPTION
Adds support for bunyan-style logs, enabled by a cli flag.

Closes GH-16