### PR TITLE
renderer: destructure message objects

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -53,6 +53,10 @@ module.exports.create = function () {
     // possible user overrides
     var colors = data.colors || {}
 
+    if (typeof data.message === 'object') {
+      data.message = destructureMessage(data.message)
+    }
+
     // clean up the messages a little
     data.level = levels.stringify(level)
     if (name) data.name = name + ':'
@@ -89,4 +93,21 @@ function getColor (key, colors, defaultColors) {
     newColor = null
   }
   return newColor || defaultColors[key]
+}
+
+// destructure a message onto an object if the message
+// is an object.
+// obj -> str
+function destructureMessage (msg) {
+  const keys = Object.keys(msg)
+  var i = 0
+  var j = keys.length
+  var res = ''
+  for (; i < j; i++) {
+    var key = keys[i]
+    var val = msg[key]
+    res += key + '=' + val
+    if (i !== j - 1) res += ', '
+  }
+  return res
 }

--- a/test/app.js
+++ b/test/app.js
@@ -20,6 +20,12 @@ console.log(JSON.stringify({
     type: 'blue'
   }
 }))
+
+console.log(JSON.stringify({
+  name: 'my-app',
+  message: { pid: 12354, port: 1336, env: 'development' }
+}))
+
 console.log({})
 var obj = new Buffer([])
 console.log(obj)


### PR DESCRIPTION
Closes GH-18. Thanks!

Changes
------
- renderer: destructure objects that are passed as message.

Example
---
Given the following ndjson:
```txt
{"name":"my-app","message":{"pid":12354,"port":1336,"env":"development"}}
```
becomes:
```txt
 info my-app: pid=12354, port=1336, env=development
```