### PR TITLE
format: prevent request

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ function garnish (opt) {
     try {
       var obj = JSON.parse(line)
 
+      if (obj.name === 'http' && obj.message === 'request') return
       if (opt.bunyan) toBunyan(obj)
 
       // check if we need to style it


### PR DESCRIPTION
Makes output in bole-ndjson more comprehensible, while not losing data (e.g. we don't have to make the program output less data; all we do is make it easier for humans to parse in postprocessing, while we can keep an original copy on the system). :shell:

__before__
<img width="488" alt="screen shot 2015-12-09 at 10 03 57" src="https://cloud.githubusercontent.com/assets/2467194/11671407/3677bfa6-9e5c-11e5-9b21-7dafd5ba8fa6.png">

__after__
<img width="449" alt="screen shot 2015-12-09 at 10 03 48" src="https://cloud.githubusercontent.com/assets/2467194/11671415/42dac7d4-9e5c-11e5-83a4-1e759669f59a.png">

