### PR TITLE
improve pino & bunyan support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ node app.js | garnish [opts]
 Options:
 
     --level, -l    the minimum debug level, default 'debug'
-    --bunyan, -b   parse bunyan logs
     --name, -n     the default app name
 ```
 
@@ -41,8 +40,6 @@ Returns a duplexer that parses input as ndjson, and writes a pretty-printed resu
 - `level` (String)
   - the minimum log level to print (default `'debug'`)
   - the order is as follows: `debug`, `info`, `warn`, `error`
-- `bunyan` (Boolean)
-  - whether to accept [bunyan](https://github.com/trentm/node-bunyan) style logs, default `false`
 - `name` (String)
   - the default name for your logger; a message's `name` field will not be printed when it matches this default name, to reduce redundant/obvious information in the logs.
 

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -4,7 +4,6 @@ var garnish = require('../')
 var argv = require('minimist')(process.argv.slice(2), {
   alias: {
     level: 'l',
-    bunyan: 'b',
     name: 'n'
   }
 })

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function garnish (opt) {
       var obj = JSON.parse(line)
 
       if (obj.name === 'http' && obj.message === 'request') return
-      if (opt.bunyan) toBunyan(obj)
+      if (typeof obj.level === 'number') toBunyan(obj)
 
       // check if we need to style it
       if (!renderer.isStyleObject(obj)) return line + eol

--- a/test/test.js
+++ b/test/test.js
@@ -17,8 +17,12 @@ test('should handle streams', function (t) {
   run('1', JSON.stringify('1'))
 
   ignored({ name: 'app', level: 'warn' }, 'should ignore level', { level: 'error' })
-  run({ name: 'app', message: 'foobar', level: 'debug' }, '[0000] debug foobar (app)', 'should not ignore default debug')
-  run({ name: 'app', level: 'debug' }, '[0000] (app)', 'prints with debug level')
+
+  const expected = '[0000] debug foobar (app)'
+  run({ name: 'app', message: 'foobar', level: 'debug' }, expected, 'should not ignore default debug')
+
+  const expected0 = '[0000] (app)'
+  run({ name: 'app', level: 'debug' }, expected0, 'prints with debug level')
 
   // test valid JSON
   // run({ name: 'foo', level: 'info' }, '[0000] ', 'shows app name and level')
@@ -26,14 +30,21 @@ test('should handle streams', function (t) {
   // run({ message: 'bar', name: 'foo' }, 'info foo: bar', 'defaults to level info')
 
   // test url and type
-  run({ url: '/home', type: 'static' }, '[0000] /home')
-  run({ url: '/home', type: 'static', name: 'app' }, '[0000] /home (app)')
+  run({ url: '/home', type: 'static' }, '[0000] /home (static)')
+  run({ url: '/home', type: 'static', name: 'app' }, '[0000] /home (static) (app)')
 
   // // test url and type + elapsed
-  run({ url: '/home', type: 'static', elapsed: 'infinity', name: 'app' }, '[0000] infinity /home (app)')
-  run({ url: '/home?blah=24#foo', type: 'static', elapsed: 'infinity', name: 'app' }, '[0000] infinity /home (app)', 'strips hash and query')
-  run({ url: 'http://localhost:9966/home?blah=24#foo', type: 'static', elapsed: 'infinity', name: 'app' }, '[0000] infinity http://localhost:9966/home (app)', 'does not strip host or port')
-  run({ url: 'http://localhost:9966/', type: 'static', elapsed: 'infinity', name: 'app' }, '[0000] infinity http://localhost:9966/ (app)', 'does not strip host or port')
+  const expected1 = '[0000] infinity /home (static) (app)'
+  run({ url: '/home', type: 'static', elapsed: 'infinity', name: 'app' }, expected1)
+
+  const expected2 = '[0000] infinity /home (static) (app)'
+  run({ url: '/home?blah=24#foo', type: 'static', elapsed: 'infinity', name: 'app' }, expected2, 'strips hash and query')
+
+  const expected3 = '[0000] infinity http://localhost:9966/home (static) (app)'
+  run({ url: 'http://localhost:9966/home?blah=24#foo', type: 'static', elapsed: 'infinity', name: 'app' }, expected3, 'does not strip host or port')
+
+  const expected4 = '[0000] infinity http://localhost:9966/ (static) (app)'
+  run({ url: 'http://localhost:9966/', type: 'static', elapsed: 'infinity', name: 'app' }, expected4, 'does not strip host or port')
 
   // level only appears on message
   // also, default name is hidden


### PR DESCRIPTION
Apparently `bunyan` and `pino` use the exact same format, this patch only improves the experience of using them. This should simplify the surface api a little bit. Thanks!

## Changes
- fixes failing tests
- auto-detects if the logs are `bunyan` based on loglevel, and formats accordingly

Closes GH-23