### PR TITLE
format: long print errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,9 @@ function garnish (opt) {
       // allow user to filter to a specific level
       if (!levels.valid(loggerLevel, obj.level)) return
 
+      // errors should be formatted differently
+      if (typeof obj.err === 'object') return renderer.renderError(obj) + eol
+
       return render(obj) + eol
     } catch (e) {
       return line + eol

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -43,6 +43,14 @@ module.exports.isStyleObject = function (data) {
   })
 }
 
+module.exports.renderError = function (data) {
+  var timeOff = String(Math.round((now() - startTime) / 1000) % 10000)
+  var line = '[' + padLeft(timeOff, 4, '0') + '] ' + chalk.red('error ')
+  line += chalk['magenta']('(' + data.name + ')') + '\n'
+  line += chalk.red(data.err.stack) + '\n'
+  return line
+}
+
 module.exports.create = function (defaultName) {
   return function render (data) {
     var level = data.level


### PR DESCRIPTION
If an `Error()` object is logged through `bole`, a `.err` property is set. This takes those hard errors and logs them properly. These types of errors should only occur in case of a programmer error (e.g. statusCode 500). Currently they're simply being swallowed by garnish :(

<img width="685" alt="screen shot 2016-03-29 at 19 11 45" src="https://cloud.githubusercontent.com/assets/2467194/14101756/2f9087a8-f5e2-11e5-8706-74c35850917e.png">

