### PR TITLE
Display extra data from the log line

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![stable](http://badges.github.io/stability-badges/dist/stable.svg)](http://github.com/badges/stability-badges)
 
-Prettifies [ndjson](http://ndjson.org/) or [bole](https://github.com/rvagg/bole) logs from [budo](https://github.com/mattdesl/budo), [wzrd](https://github.com/maxogden/wzrd/) and other tools. 
+Prettifies [ndjson](http://ndjson.org/) or [bole](https://github.com/rvagg/bole) logs from [budo](https://github.com/mattdesl/budo), [wzrd](https://github.com/maxogden/wzrd/) and other tools.
 
 Example with [budo](https://github.com/mattdesl/budo), which uses this under the hood.
 
@@ -42,6 +42,8 @@ Returns a duplexer that parses input as ndjson, and writes a pretty-printed resu
   - the order is as follows: `debug`, `info`, `warn`, `error`
 - `name` (String)
   - the default name for your logger; a message's `name` field will not be printed when it matches this default name, to reduce redundant/obvious information in the logs.
+- `showData` (Boolean)
+  - should fields that are not specifically handled be printed at the end of the line. Defaults to `false`.
 
 ## format
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function garnish (opt) {
   opt = opt || {}
 
   var loggerLevel = opt.level || 'debug'
-  var render = renderer.create(opt.name)
+  var render = renderer.create(opt.name, opt.showData)
 
   return split(parse)
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -61,7 +61,7 @@ exports.renderObject = function (data) {
   return line
 }
 
-exports.create = function (defaultName) {
+exports.create = function (defaultName, showData) {
   return function render (data) {
     var level = data.level
     var name = data.name
@@ -138,6 +138,15 @@ exports.create = function (defaultName) {
 
       line.push(value)
     })
+
+    if (showData) {
+      var shownData = Object.assign({}, data)
+      keys.forEach(function (key) {
+        delete shownData[key]
+      })
+      line.push(destructureMessage(shownData))
+    }
+
     return line.join(' ')
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -63,6 +63,29 @@ test('should handle streams', function (t) {
     contentLength: '12b',
     elapsed: '24ms'
   }, '[0000] 24ms         12B 200 /home (generated)', 'test all fields', { name: 'myApp' })
+
+  // test display data
+  run({
+    name: 'myApp',
+    url: '/home',
+    type: 'generated',
+    statusCode: '200',
+    contentLength: '12b',
+    elapsed: '24ms',
+    data: 'foobar'
+  }, '[0000] 24ms         12B 200 /home (generated)   "data": "foobar"', 'test all fields with shown data', { name: 'myApp', showData: true })
+
+  // dont show by default
+  run({
+    name: 'myApp',
+    url: '/home',
+    type: 'generated',
+    statusCode: '200',
+    contentLength: '12b',
+    elapsed: '24ms',
+    data: 'foobar'
+  }, '[0000] 24ms         12B 200 /home (generated)', 'test all fields with hidden data', { name: 'myApp' })
+
   t.end()
 
   function ignored (input, msg, opt) {


### PR DESCRIPTION
This gives an option to have json output of any extra keys from the json message that's similar to an object message. This is helpful if your developers like to log extra helpful info along with a text message. No worries if you don't want to add this feature, but I thought it was helpful so I made sure to give it a pr.